### PR TITLE
Dependabot

### DIFF
--- a/.github/dependabot-base.yml
+++ b/.github/dependabot-base.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+  - package-ecosystem: terraform
+    directory: /Terraform_modules/ec2_instance
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+  - package-ecosystem: terraform
+    directory: /Terraform_modules/rds_serverless_cluster
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+  - package-ecosystem: terraform
+    directory: /Terraform_modules/vpc_subnets
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# This file is auto-generated from dependabot-base.yml
 version: 2
 updates:
   - package-ecosystem: github-actions

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -94,6 +94,7 @@ jobs:
           MODULES: ${{ needs.determine-modules.outputs.modules }}
         run: |
           cp .github/dependabot-base.yml .github/dependabot.yml
+          sed -i '1i # This file is auto-generated from dependabot-base.yml' .github/dependabot.yml
 
           jq -r '.[]' <<< "$MODULES" | while read MODULE; do
             cat <<EOF >> .github/dependabot.yml

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -75,3 +75,42 @@ jobs:
           config-file: "${{ github.workspace }}/.terraform-docs.yml"
           output-method: inject
           git-push: "true"
+
+  dependabot:
+    name: Update Dependabot Entries
+    runs-on: ubuntu-latest
+    needs: determine-modules
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Update dependabot.yml
+        env:
+          MODULES: ${{ needs.determine-modules.outputs.modules }}
+        run: |
+          cp .github/dependabot-base.yml .github/dependabot.yml
+
+          jq -r '.[]' <<< "$MODULES" | while read MODULE; do
+            cat <<EOF >> .github/dependabot.yml
+            - package-ecosystem: terraform
+              directory: /Terraform_modules/$MODULE
+              schedule:
+                interval: daily
+              ignore:
+                - dependency-name: "*"
+                  update-types:
+                    - "version-update:semver-patch"
+                    - "version-update:semver-minor"
+          EOF
+          done
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update dependabot terraform entries
+          commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          file_pattern: .github/dependabot.yml
+          skip_checkout: true
+

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -79,7 +79,9 @@ jobs:
   dependabot:
     name: Update Dependabot Entries
     runs-on: ubuntu-latest
-    needs: determine-modules
+    needs:
+      - determine-modules
+      - terraform-docs # to avoid race condition with both committing
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Dependabot does not support recursive directories (see dependabot/dependabot-core#649, dependabot/dependabot-core#3951).

This PR creates a dependabot entry for each module in the repo using the same list that powers the actions matrix.
